### PR TITLE
Refactor Supabase client usage

### DIFF
--- a/login.js
+++ b/login.js
@@ -1,10 +1,5 @@
-import { createClient } from '@supabase/supabase-js';
+import supabase from './src/utils/supabaseClient.js';
 import { initMenu } from './src/utils/menu.js';
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
 
 document.addEventListener('DOMContentLoaded', () => {
   // Initialize the menu

--- a/main.jsx
+++ b/main.jsx
@@ -1,10 +1,5 @@
-import { createClient } from '@supabase/supabase-js';
+import supabase from './src/utils/supabaseClient.js';
 import { initMenu } from './src/utils/menu';
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
 
 document.querySelector('#app').innerHTML = `
   <div>

--- a/publish.js
+++ b/publish.js
@@ -1,10 +1,5 @@
-import { createClient } from '@supabase/supabase-js';
+import supabase from './src/utils/supabaseClient.js';
 import { initMenu } from './src/utils/menu.js';
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
 
 // Tag management arrays
 let archiveTags = [];

--- a/reset-password.js
+++ b/reset-password.js
@@ -1,10 +1,5 @@
-import { createClient } from '@supabase/supabase-js';
+import supabase from './src/utils/supabaseClient.js';
 import { initMenu } from './src/utils/menu.js';
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
 
 document.addEventListener('DOMContentLoaded', () => {
   // Initialize the menu

--- a/settings.js
+++ b/settings.js
@@ -1,9 +1,4 @@
-import { createClient } from '@supabase/supabase-js';
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
+import supabase from './src/utils/supabaseClient.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const profileForm = document.getElementById('profile-form');

--- a/src/browse-archive.js
+++ b/src/browse-archive.js
@@ -1,10 +1,5 @@
-import { createClient } from '@supabase/supabase-js';
+import supabase from './utils/supabaseClient.js';
 import { initMenu } from './utils/menu.js';
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
 
 let currentUser = null;
 let currentPage = 1;

--- a/src/browse-collab.js
+++ b/src/browse-collab.js
@@ -1,10 +1,5 @@
-import { createClient } from '@supabase/supabase-js';
+import supabase from './utils/supabaseClient.js';
 import { initMenu } from './utils/menu.js';
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
 
 let currentUser = null;
 let currentPage = 1;

--- a/src/favorites.js
+++ b/src/favorites.js
@@ -1,10 +1,5 @@
-import { createClient } from '@supabase/supabase-js';
+import supabase from './utils/supabaseClient.js';
 import { initMenu } from './utils/menu.js';
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
 
 let currentUser = null;
 

--- a/src/profile.js
+++ b/src/profile.js
@@ -1,10 +1,5 @@
-import { createClient } from '@supabase/supabase-js';
+import supabase from './utils/supabaseClient.js';
 import { initMenu } from './utils/menu.js';
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
 
 let currentUser = null;
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,10 +1,5 @@
-import { createClient } from '@supabase/supabase-js';
+import supabase from './utils/supabaseClient.js';
 import { initMenu } from './utils/menu.js';
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
 
 document.addEventListener('DOMContentLoaded', async () => {
   // Initialize the side menu

--- a/src/utils/favorites.js
+++ b/src/utils/favorites.js
@@ -1,9 +1,4 @@
-import { createClient } from '@supabase/supabase-js';
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
+import supabase from './supabaseClient.js';
 
 let currentUser = null;
 

--- a/src/view-post.js
+++ b/src/view-post.js
@@ -1,10 +1,5 @@
-import { createClient } from '@supabase/supabase-js';
+import supabase from './utils/supabaseClient.js';
 import { initMenu } from './utils/menu.js';
-
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
 
 let currentUser = null;
 let currentPost = null;


### PR DESCRIPTION
## Summary
- import the centralized Supabase client in all scripts
- remove duplicate `createClient` calls

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e213db748333a6b12b9758760fa9