### PR TITLE
Add basic Vitest setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.4.0"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.7"

--- a/tests/sanity.test.js
+++ b/tests/sanity.test.js
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('sanity check', () => {
+  it('true is true', () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest as a dev dependency with a test script
- create a sample sanity test

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e92e4e6c833395a060d560224f5f