### PR TITLE
Fix import extensions

### DIFF
--- a/main.jsx
+++ b/main.jsx
@@ -1,5 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
-import { initMenu } from './src/utils/menu';
+import { initMenu } from './src/utils/menu.js';
 
 const supabase = createClient(
   import.meta.env.VITE_SUPABASE_URL,

--- a/src/activity.js
+++ b/src/activity.js
@@ -1,4 +1,4 @@
-import { initMenu } from './utils/menu';
+import { initMenu } from './utils/menu.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   initMenu();

--- a/src/help.js
+++ b/src/help.js
@@ -1,4 +1,4 @@
-import { initMenu } from './utils/menu';
+import { initMenu } from './utils/menu.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   initMenu();

--- a/src/utils/menu.js
+++ b/src/utils/menu.js
@@ -1,4 +1,4 @@
-import supabase from './supabaseClient';
+import supabase from './supabaseClient.js';
 
 export async function initMenu() {
   // Select existing menu elements


### PR DESCRIPTION
## Summary
- use explicit `.js` extension for Supabase client in `menu.js`
- update remaining modules to use `.js` extension when importing `menu.js`

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e610a34c8333bcf86d5a4f22919d