### PR TITLE
Ensure popups have close buttons

### DIFF
--- a/login.html
+++ b/login.html
@@ -29,6 +29,21 @@
           0 0 60px rgba(6, 114, 115, 0.1);
         animation: formGlow 2s ease-in-out infinite alternate;
       }
+
+      .close-login-btn {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        background: transparent;
+        border: none;
+        font-size: 24px;
+        color: #067273;
+        cursor: pointer;
+      }
+
+      .close-login-btn:hover {
+        color: #045c66;
+      }
       
       .login-header {
         background-color: #07717c;
@@ -282,6 +297,7 @@
     </div>
     
     <div class="login-container">
+      <button class="close-login-btn" id="close-login-btn" title="Close">&#10005;</button>
       <div class="login-header">
         <h1>Login</h1>
       </div>

--- a/src/login.js
+++ b/src/login.js
@@ -18,6 +18,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const forgotPasswordLink = document.querySelector('.forgot-password');
   const googleSigninButton = document.getElementById('google-signin');
   const googleSignupButton = document.getElementById('google-signup');
+  const closeBtn = document.getElementById('close-login-btn');
+
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => {
+      window.history.back();
+    });
+  }
   
   // Add error message elements after forms load
   const signinErrorDisplay = document.createElement('div');

--- a/src/utils/menu.js
+++ b/src/utils/menu.js
@@ -19,6 +19,19 @@ export async function initMenu() {
     menuOptions.className = 'menu-options';
     document.body.appendChild(menuOptions);
   }
+
+  // Add a close button to the menu if it doesn't exist
+  if (!menuOptions.querySelector('.close-menu-btn')) {
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'close-menu-btn';
+    closeBtn.innerHTML = '&times;';
+    closeBtn.title = 'Close';
+    closeBtn.addEventListener('click', () => {
+      isMenuLockedOpen = false;
+      closeMenu();
+    });
+    menuOptions.prepend(closeBtn);
+  }
   
   // Get authentication status
   const { data: { session } } = await supabase.auth.getSession();

--- a/style.css
+++ b/style.css
@@ -402,6 +402,21 @@ body {
   overflow-y: auto;
 }
 
+.close-menu-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: transparent;
+  border: none;
+  font-size: 24px;
+  color: #067273;
+  cursor: pointer;
+}
+
+.close-menu-btn:hover {
+  color: #045c66;
+}
+
 .menu-options.active {
   transform: translateX(300px);
   box-shadow:


### PR DESCRIPTION
## Summary
- add a close button to the login page
- enable closing the login page via JS
- add close button to the menu
- style the new close buttons

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853cc57831083339efb06dc3d6bc349