### PR TITLE
Add recently viewed tracker

### DIFF
--- a/src/utils/menu.js
+++ b/src/utils/menu.js
@@ -30,6 +30,7 @@ export async function initMenu() {
   function openMenu() {
     menuOptions.classList.add('active');
     menuOverlay.classList.add('active');
+    renderRecentlyViewed();
   }
 
   function closeMenu() {
@@ -91,7 +92,7 @@ export async function initMenu() {
       menuOptions.insertBefore(menuTop, existingChildren[0]);
     } else {
       menuOptions.appendChild(menuTop);
-      
+
       // Add recent searches section if it doesn't exist and this isn't the info-hub page
       if (!document.querySelector('.info-nav')) {
         const recentSearches = document.createElement('div');
@@ -107,6 +108,22 @@ export async function initMenu() {
           </button>
         `;
         menuOptions.appendChild(recentSearches);
+      }
+    }
+
+    // Insert recently viewed section
+    if (!menuOptions.querySelector('.recently-viewed')) {
+      const recentlyViewed = document.createElement('div');
+      recentlyViewed.className = 'recently-viewed';
+      recentlyViewed.innerHTML = `
+        <h3>Recently Viewed</h3>
+        <div class="recently-viewed-list"></div>
+      `;
+      const infoNav = menuOptions.querySelector('.info-nav');
+      if (infoNav) {
+        menuOptions.insertBefore(recentlyViewed, infoNav.nextSibling);
+      } else {
+        menuOptions.appendChild(recentlyViewed);
       }
     }
     
@@ -254,5 +271,29 @@ export async function initMenu() {
     if (e.relatedTarget !== leftEdgeTrigger && e.relatedTarget !== hamburgerIcon && !isMenuLockedOpen) {
       closeMenu();
     }
+  });
+}
+
+function renderRecentlyViewed() {
+  const listContainer = menuOptions.querySelector('.recently-viewed-list');
+  if (!listContainer) return;
+
+  const items = JSON.parse(localStorage.getItem('recentlyViewedPosts') || '[]');
+  listContainer.innerHTML = '';
+
+  if (items.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.textContent = 'Empty';
+    listContainer.appendChild(empty);
+    return;
+  }
+
+  items.forEach((item) => {
+    const link = document.createElement('a');
+    link.href = `/view-post.html?id=${item.id}&type=${item.type}`;
+    link.textContent = item.title;
+    link.className = 'recent-item';
+    listContainer.appendChild(link);
   });
 }

--- a/src/view-post.js
+++ b/src/view-post.js
@@ -184,8 +184,10 @@ async function loadAndDisplayPost(postId, postType, container) {
     if (!post) {
       throw new Error('Post not found');
     }
-    
+
     currentPost = post;
+
+    addRecentlyViewed(post.id, postType, post.title);
     
     // Increment view count
     await incrementViewCount(postId, postType);
@@ -715,4 +717,18 @@ function showError(message) {
       </a>
     </div>
   `;
+}
+
+function addRecentlyViewed(id, type, title) {
+  const key = 'recentlyViewedPosts';
+  const maxItems = 5;
+  let items = [];
+  try {
+    items = JSON.parse(localStorage.getItem(key)) || [];
+  } catch (e) {}
+
+  items = items.filter(p => !(p.id === id && p.type === type));
+  items.unshift({ id, type, title });
+  if (items.length > maxItems) items = items.slice(0, maxItems);
+  localStorage.setItem(key, JSON.stringify(items));
 }

--- a/style.css
+++ b/style.css
@@ -510,6 +510,33 @@ body {
   margin-bottom: 10px;
 }
 
+.recently-viewed {
+  padding: 20px;
+  margin-top: 10px;
+}
+
+.recently-viewed h3 {
+  color: #07717c;
+  font-size: 16px;
+  font-weight: 500;
+  margin-bottom: 10px;
+}
+
+.recent-item {
+  display: block;
+  color: #07717c;
+  text-decoration: none;
+  opacity: 0.8;
+  font-size: 14px;
+  padding: 6px 0;
+  transition: opacity 0.2s ease;
+}
+
+.recent-item:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
+
 .empty-state {
   color: #07717c;
   opacity: 0.7;


### PR DESCRIPTION
## Summary
- track recently viewed posts in `view-post.js`
- show list of recently viewed posts in slide-out menu via `menu.js`
- style the new section in `style.css`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853cc211618833384e9f9970c0393a3